### PR TITLE
Fixed unnecessary uniform location lookups

### DIFF
--- a/src/decals/dotted-circle/DottedCircle.ts
+++ b/src/decals/dotted-circle/DottedCircle.ts
@@ -2,6 +2,7 @@ import { Color, Layer } from '../../objects';
 
 import vertexShaderCode from './vertex.glsl?raw';
 import fragmentShaderCode from './fragment.glsl?raw';
+import { Util } from '../../util';
 
 export class DottedCircle extends Layer {
 	private readonly numberOfDots: number
@@ -20,16 +21,16 @@ export class DottedCircle extends Layer {
 
 	public setUp(context: WebGL2RenderingContext): void {
 		this.setUpProgram(context, vertexShaderCode, fragmentShaderCode)
-		this.program?.setUniform("2f", "resolution", context.canvas.width, context.canvas.height)
+		this.program?.setUniform("resolution", context.canvas.width, context.canvas.height)
 		this.program?.setColor("color", this.color)
-		this.program?.setUniform("1i", "numberOfDots", this.numberOfDots)
-		this.program?.setUniform("1f", "radius", this.radius)
+		this.program?.setUniform("numberOfDots", this.numberOfDots)
+		this.program?.setUniform("radius", this.radius)
 	}
 
 	public render(): void {
-		const offset = (Date.now() % 1000) / 1000
+		const offset = (Date.now() % Util.MILLISECONDS_PER_SECOND) / Util.MILLISECONDS_PER_SECOND
 		this.program?.use()
-		this.program?.setUniform("1f", "offset", offset)
+		this.program?.setUniform("offset", offset)
 		this.context?.drawArrays(this.context.POINTS, 0, this.numberOfDots);
 	}
 }

--- a/src/decals/falling-dots/FallingDots.ts
+++ b/src/decals/falling-dots/FallingDots.ts
@@ -1,10 +1,10 @@
 import { Color, Layer } from '../../objects';
+import { Util } from '../../util';
 
 import vertexShaderCode from './vertex.glsl?raw';
 import fragmentShaderCode from './fragment.glsl?raw';
 
 export class FallingDots extends Layer {
-	private static readonly MILLISECONDS_PER_SECOND = 1000
 	public static readonly MAX_NUMBER_OF_UNIQUE_ITERATIONS = 100000
 	private readonly numberOfDots: number
 	private readonly numberOfUniqueIterations: number
@@ -25,15 +25,14 @@ export class FallingDots extends Layer {
 	public setUp(context: WebGL2RenderingContext): void {
 		this.setUpProgram(context, vertexShaderCode, fragmentShaderCode)
 		this.program?.setColor("color", this.color)
-		this.program?.setUniform("1i", "numberOfDots", this.numberOfDots)
-		this.program?.setUniform("1i", "numberOfUniqueIterations", this.numberOfUniqueIterations)
+		this.program?.setUniform("numberOfUniqueIterations", this.numberOfUniqueIterations)
 	}
 
 	public render(): void {
-		const iterationDurationInMilliseconds = FallingDots.MILLISECONDS_PER_SECOND * this.iterationDurationInSeconds
+		const iterationDurationInMilliseconds = Util.MILLISECONDS_PER_SECOND * this.iterationDurationInSeconds
 		const continuousFloatBetweenZeroAndIterationCount = (Date.now() / iterationDurationInMilliseconds) % this.numberOfUniqueIterations
 		this.program?.use()
-		this.program?.setUniform("1f", "continuousFloatBetweenZeroAndIterationCount", continuousFloatBetweenZeroAndIterationCount)
+		this.program?.setUniform("continuousFloatBetweenZeroAndIterationCount", continuousFloatBetweenZeroAndIterationCount)
 		this.context?.drawArrays(this.context.POINTS, 0, this.numberOfDots);
 	}
 }

--- a/src/decals/falling-dots/vertex.glsl
+++ b/src/decals/falling-dots/vertex.glsl
@@ -1,8 +1,6 @@
 #version 300 es
 uniform float continuousFloatBetweenZeroAndIterationCount;
 uniform int numberOfUniqueIterations;
-uniform int numberOfDots;
-uniform vec2 resolution;
 
 float noise(in float seed) {
 	return fract(tan(seed) * 1000.0);

--- a/src/objects/Decal.ts
+++ b/src/objects/Decal.ts
@@ -1,5 +1,6 @@
 import { Layer } from './Layer';
 import { DecalError } from './errors';
+import { Util } from '../util';
 
 export class Decal {
 	private readonly canvas: HTMLCanvasElement
@@ -14,7 +15,7 @@ export class Decal {
 	) {
 		try {
 			const configuration = { ...defaultConfiguration, ...configurationOverwrites }
-			this.millisecondsBetweenFrames = 1000 / configuration.targetFrameRate
+			this.millisecondsBetweenFrames = Util.MILLISECONDS_PER_SECOND / configuration.targetFrameRate
 			this.canvas = this.createCanvas(configuration.width, configuration.height)
 			this.context = this.createContext()
 

--- a/src/objects/Layer.ts
+++ b/src/objects/Layer.ts
@@ -13,7 +13,6 @@ export abstract class Layer {
 			new Shader(fragmentShaderCode, "fragment")
 		])
 		this.program.use()
-		console.debug("--- Program complete ---")
 	}
 
 	public abstract render(): void

--- a/src/objects/Layer.ts
+++ b/src/objects/Layer.ts
@@ -13,6 +13,7 @@ export abstract class Layer {
 			new Shader(fragmentShaderCode, "fragment")
 		])
 		this.program.use()
+		console.debug("--- Program complete ---")
 	}
 
 	public abstract render(): void

--- a/src/objects/errors/DecalError.ts
+++ b/src/objects/errors/DecalError.ts
@@ -1,3 +1,5 @@
+import { WebGlError } from './WebGlError';
+
 export class DecalError extends Error {
 
 	constructor(message: string, public cause: unknown) {
@@ -10,7 +12,15 @@ export class DecalError extends Error {
 		stringRepresentation += "\n"
 		stringRepresentation += this.stack
 		stringRepresentation += "\n"
-		stringRepresentation += this.cause
+		if(this.cause instanceof WebGlError) {
+			stringRepresentation += this.cause
+		} else if(this.cause instanceof Error) {
+			stringRepresentation += this.cause.message
+			stringRepresentation += "\n"
+			stringRepresentation += this.cause.stack
+		} else {
+			stringRepresentation += this.cause
+		}
 		return stringRepresentation
 	}
 }

--- a/src/objects/webgl/Program.ts
+++ b/src/objects/webgl/Program.ts
@@ -1,6 +1,4 @@
-import { Shader, Uniform } from './Shader';
-import { WebGlError } from '../index';
-import { Color } from './Color';
+import { Shader, Uniform, Color, WebGlError } from '..';
 
 export class Program {
 	public readonly program: WebGLProgram

--- a/src/objects/webgl/Program.ts
+++ b/src/objects/webgl/Program.ts
@@ -1,14 +1,13 @@
-import { Shader } from './Shader';
+import { Shader, Uniform } from './Shader';
 import { WebGlError } from '../index';
 import { Color } from './Color';
 
-export type UniformType = "1i" | "1f" | "2f" | "4f"
-
 export class Program {
-	private readonly program: WebGLProgram
+	public readonly program: WebGLProgram
+	public readonly uniforms = new Map<string, Uniform>()
 
 	public constructor(
-		private readonly context: WebGL2RenderingContext,
+		public readonly context: WebGL2RenderingContext,
 		shaders: Shader[]
 	) {
 		this.program = this.createProgram()
@@ -17,6 +16,9 @@ export class Program {
 			context.attachShader(this.program, shader)
 		context.linkProgram(this.program)
 		this.validate()
+		for(const shader of shaders)
+			for(const uniform of shader.getUniforms(this))
+				this.uniforms.set(uniform.name, uniform)
 		for(const shader of webGlShaders) {
 			context.detachShader(this.program, shader)
 			context.deleteShader(shader)
@@ -34,15 +36,15 @@ export class Program {
 		this.context.useProgram(this.program)
 	}
 
-	public setUniform(type: UniformType, name: string, ...values: number[]): void {
-		const location = this.context.getUniformLocation(this.program, name)
-		// @ts-ignore - Dynamic amount of parameters,
-		// because the possible function take different numbers of parameters
-		this.context[`uniform${type}`](location, ...values)
+	public setUniform(name: string, ...values: number[]): void {
+		const uniform = this.uniforms.get(name)
+		if(!uniform)
+			throw new Error(`Failed to set value(s) of uniform '${name}': Not found.`)
+		uniform.setValues(...values)
 	}
 
 	public setColor(name: string, color: Color): void {
-		this.setUniform("4f", name, ...color.getWebGlValues())
+		this.setUniform(name, ...color.getWebGlValues())
 	}
 
 	private validate(): void {

--- a/src/objects/webgl/Shader.ts
+++ b/src/objects/webgl/Shader.ts
@@ -1,59 +1,6 @@
 import { WebGlError } from '../errors';
 import { Program } from './Program';
-
-export class Uniform {
-	private static readonly NOT_FOUND = -1
-	private readonly memoryLocation: WebGLUniformLocation
-	private readonly storeFunctionName: string
-
-	public constructor(
-		private readonly program: Program,
-		private readonly type: string,
-		public readonly name: string,
-	) {
-		const memoryLocation = program.context.getUniformLocation(program.program, name)
-		if(!memoryLocation)
-			throw new Error(`Failed to find memory location of uniform '${this}'.`)
-		this.memoryLocation = memoryLocation
-		this.storeFunctionName = this.getStoreFunctionName()
-	}
-
-	public setValues(...values: number[]): void {
-		// @ts-ignore - Dynamic amount of parameters,
-		// because the possible function take different numbers of parameters
-		this.program.context[this.storeFunctionName](this.memoryLocation, ...values)
-	}
-
-	private getStoreFunctionName(): string {
-		// Detects types in the format of: <1-4> <i|ui|iv|uiv|f|fv>
-		const vectorType = "vec"
-		const vecPosition = this.type.indexOf(vectorType)
-		let valueCount: string
-		let baseType: string|null = null
-		if(vecPosition === Uniform.NOT_FOUND) {
-			valueCount = "1"
-		} else {
-			valueCount = this.type.substring(vecPosition + vectorType.length)
-			if(this.type.startsWith(vectorType))
-				baseType = "f" //TODO is this guaranteed to be a float?
-		}
-		if(this.type.startsWith("i")) {
-			baseType = "i"
-		} else if(this.type.startsWith("f")) {
-			baseType = "f"
-		} else if(this.type.startsWith("u")) {
-			baseType = "ui"
-		} else if(!baseType) {
-			throw new Error(`Failed to determine WebGL2 type of '${this}'.`)
-		}
-		//TODO does not handle array and matrix types
-		return `uniform${valueCount + baseType}`
-	}
-
-	public toString(): string {
-		return `uniform ${this.type} ${this.name};`
-	}
-}
+import { Uniform } from './Uniform';
 
 export class Shader {
 	private static readonly UNIFORM_REGEX = /^uniform\s+(?<type>\w+)\s+(?<name>\w+);/gm

--- a/src/objects/webgl/Shader.ts
+++ b/src/objects/webgl/Shader.ts
@@ -1,10 +1,66 @@
 import { WebGlError } from '../errors';
+import { Program } from './Program';
 
-export class Shader {
+export class Uniform {
+	private static readonly NOT_FOUND = -1
+	private readonly memoryLocation: WebGLUniformLocation
+	private readonly storeFunctionName: string
 
 	public constructor(
-		private code: string,
-		private type: "vertex" | "fragment"
+		private readonly program: Program,
+		private readonly type: string,
+		public readonly name: string,
+	) {
+		const memoryLocation = program.context.getUniformLocation(program.program, name)
+		if(!memoryLocation)
+			throw new Error(`Failed to find memory location of uniform '${this}'.`)
+		this.memoryLocation = memoryLocation
+		this.storeFunctionName = this.getStoreFunctionName()
+	}
+
+	public setValues(...values: number[]): void {
+		// @ts-ignore - Dynamic amount of parameters,
+		// because the possible function take different numbers of parameters
+		this.program.context[this.storeFunctionName](this.memoryLocation, ...values)
+	}
+
+	private getStoreFunctionName(): string {
+		// Detects types in the format of: <1-4> <i|ui|iv|uiv|f|fv>
+		const vectorType = "vec"
+		const vecPosition = this.type.indexOf(vectorType)
+		let valueCount: string
+		let baseType: string|null = null
+		if(vecPosition === Uniform.NOT_FOUND) {
+			valueCount = "1"
+		} else {
+			valueCount = this.type.substring(vecPosition + vectorType.length)
+			if(this.type.startsWith(vectorType))
+				baseType = "f" //TODO is this guaranteed to be a float?
+		}
+		if(this.type.startsWith("i")) {
+			baseType = "i"
+		} else if(this.type.startsWith("f")) {
+			baseType = "f"
+		} else if(this.type.startsWith("u")) {
+			baseType = "ui"
+		} else if(!baseType) {
+			throw new Error(`Failed to determine WebGL2 type of '${this}'.`)
+		}
+		//TODO does not handle array and matrix types
+		return `uniform${valueCount + baseType}`
+	}
+
+	public toString(): string {
+		return `uniform ${this.type} ${this.name};`
+	}
+}
+
+export class Shader {
+	private static readonly UNIFORM_REGEX = /^uniform\s+(?<type>\w+)\s+(?<name>\w+);/gm
+
+	public constructor(
+		private readonly code: string,
+		private readonly type: "vertex" | "fragment"
 	) {}
 
 	public getWebGlShader(context: WebGL2RenderingContext): WebGLShader {
@@ -13,6 +69,23 @@ export class Shader {
 		context.compileShader(shader)
 		this.validate(context, shader)
 		return shader
+	}
+
+	public getUniforms(program: Program): Uniform[] {
+		const uniforms: Uniform[] = []
+		while(true) {
+			const uniform = Shader.UNIFORM_REGEX.exec(this.code)
+			if(!uniform)
+				break
+			const type = uniform?.groups?.["type"]
+			if(!type)
+				throw new Error("Failed to extract type of uniform.")
+			const name = uniform?.groups?.["name"]
+			if(!name)
+				throw new Error("Failed to extract name of uniform.")
+			uniforms.push(new Uniform(program, type, name))
+		}
+		return uniforms
 	}
 
 	private createShader(context: WebGL2RenderingContext): WebGLShader {

--- a/src/objects/webgl/Uniform.ts
+++ b/src/objects/webgl/Uniform.ts
@@ -1,0 +1,55 @@
+import { Program } from './Program';
+
+export class Uniform {
+	private static readonly NOT_FOUND = -1
+	private readonly memoryLocation: WebGLUniformLocation
+	private readonly storeFunctionName: string
+
+	public constructor(
+		private readonly program: Program,
+		private readonly type: string,
+		public readonly name: string,
+	) {
+		const memoryLocation = program.context.getUniformLocation(program.program, name)
+		if(!memoryLocation)
+			throw new Error(`Failed to find memory location of uniform '${this}'.`)
+		this.memoryLocation = memoryLocation
+		this.storeFunctionName = this.getStoreFunctionName()
+	}
+
+	public setValues(...values: number[]): void {
+		// @ts-ignore - Dynamic amount of parameters,
+		// because the possible function take different numbers of parameters
+		this.program.context[this.storeFunctionName](this.memoryLocation, ...values)
+	}
+
+	private getStoreFunctionName(): string {
+		// Detects types in the format of: <1-4> <i|ui|iv|uiv|f|fv>
+		const vectorType = "vec"
+		const vecPosition = this.type.indexOf(vectorType)
+		let valueCount: string
+		let baseType: string|null = null
+		if(vecPosition === Uniform.NOT_FOUND) {
+			valueCount = "1"
+		} else {
+			valueCount = this.type.substring(vecPosition + vectorType.length)
+			if(this.type.startsWith(vectorType))
+				baseType = "f" //TODO is this guaranteed to be a float?
+		}
+		if(this.type.startsWith("i")) {
+			baseType = "i"
+		} else if(this.type.startsWith("f")) {
+			baseType = "f"
+		} else if(this.type.startsWith("u")) {
+			baseType = "ui"
+		} else if(!baseType) {
+			throw new Error(`Failed to determine WebGL2 type of '${this}'.`)
+		}
+		//TODO does not handle array and matrix types
+		return `uniform${valueCount + baseType}`
+	}
+
+	public toString(): string {
+		return `uniform ${this.type} ${this.name};`
+	}
+}

--- a/src/objects/webgl/index.ts
+++ b/src/objects/webgl/index.ts
@@ -1,3 +1,4 @@
 export * from './Color';
 export * from './Program';
 export * from './Shader';
+export * from './Uniform';

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -1,0 +1,3 @@
+export class Util {
+	public static readonly MILLISECONDS_PER_SECOND = 1000
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,1 +1,1 @@
-export {}
+export * from './Util'


### PR DESCRIPTION
## Issue

- https://github.com/Minding000/background-decals/issues
- Unused variables in shader.
- Missing stack trace in `DecalError`.

## Changes

- Moved uniform location lookups to layer initialization.
- Improved `DecalError` console output.
- Added utility class.
- Removed unused variables in shader.
